### PR TITLE
Remove Nodd from the maintainers team [ci skip]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Nodd @astrofrog-conda-forge @ccordoba12 @dalthviz
+* @astrofrog-conda-forge @ccordoba12 @dalthviz

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@Nodd](https://github.com/Nodd/)
 * [@astrofrog-conda-forge](https://github.com/astrofrog-conda-forge/)
 * [@ccordoba12](https://github.com/ccordoba12/)
 * [@dalthviz](https://github.com/dalthviz/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,5 +42,4 @@ extra:
   recipe-maintainers:
     - ccordoba12
     - astrofrog-conda-forge
-    - Nodd
     - dalthviz


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Nodd hasn't been active in the development of this project for a very long team and the Conda-forge bot reports him as a new maintainer after every PR.

<!--
Please add any other relevant info below:
-->
